### PR TITLE
fix: replace CreateArchetype with CreateEntity + AddComponentData

### DIFF
--- a/research/topics/EmergencyDispatch/README.md
+++ b/research/topics/EmergencyDispatch/README.md
@@ -632,12 +632,9 @@ If you want to dispatch without a real event, ensure the validation component ex
 >
 > ```csharp
 > // CORRECT: Create an event entity for AddHealthProblemSystem to process
-> var archetype = EntityManager.CreateArchetype(
->     ComponentType.ReadWrite<Game.Common.Event>(),
->     ComponentType.ReadWrite<AddHealthProblem>()
-> );
-> Entity cmd = EntityManager.CreateEntity(archetype);
-> EntityManager.SetComponentData(cmd, new AddHealthProblem
+> Entity cmd = EntityManager.CreateEntity();
+> EntityManager.AddComponentData(cmd, new Game.Common.Event());
+> EntityManager.AddComponentData(cmd, new AddHealthProblem
 > {
 >     m_Event = Entity.Null,
 >     m_Target = citizenEntity,

--- a/site/emergency-dispatch.html
+++ b/site/emergency-dispatch.html
@@ -769,12 +769,9 @@ private void DispatchAmbulanceTo(Entity citizen)
   </p>
 
   <pre><code class="language-csharp">// CORRECT: Create an event entity for AddHealthProblemSystem to process
-var archetype = EntityManager.CreateArchetype(
-    ComponentType.ReadWrite&lt;Game.Common.Event&gt;(),
-    ComponentType.ReadWrite&lt;AddHealthProblem&gt;()
-);
-Entity cmd = EntityManager.CreateEntity(archetype);
-EntityManager.SetComponentData(cmd, new AddHealthProblem
+Entity cmd = EntityManager.CreateEntity();
+EntityManager.AddComponentData(cmd, new Game.Common.Event());
+EntityManager.AddComponentData(cmd, new AddHealthProblem
 {
     m_Event = Entity.Null,
     m_Target = citizenEntity,


### PR DESCRIPTION
## Summary
- Replace `EntityManager.CreateArchetype()` + `CreateEntity(archetype)` with `EntityManager.CreateEntity()` + individual `AddComponentData()` calls in the EmergencyDispatch HealthProblem warning section
- `CreateArchetype` requires `params ComponentType[]` which is not available on .NET Standard 2.1
- Fixes both `research/topics/EmergencyDispatch/README.md` and `site/emergency-dispatch.html`

## Test plan
- [ ] Verify the code examples in the HealthProblem warning section use `CreateEntity()` + `AddComponentData()` pattern
- [ ] Confirm no remaining `CreateArchetype` calls in EmergencyDispatch files

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)