### PR TITLE
fix: resolve onClick vs onSelect contradiction in ModUIButtons

### DIFF
--- a/research/topics/ModUIButtons/README.md
+++ b/research/topics/ModUIButtons/README.md
@@ -1023,7 +1023,7 @@ InfoLoom implements a multi-level menu as a conditionally-rendered absolutely-po
         <div className={styles.buttonRow}>
             {sections.map(name => (
                 <Button key={name} variant="flat"
-                    onClick={() => toggleSection(name)}>
+                    onSelect={() => toggleSection(name)}>
                     {name}
                 </Button>
             ))}
@@ -1031,6 +1031,12 @@ InfoLoom implements a multi-level menu as a conditionally-rendered absolutely-po
     </div>
 )}
 ```
+
+> **Note on `onSelect` vs `onClick`:** The `cs2/ui` `Button` component extends
+> `React.ButtonHTMLAttributes`, so both `onSelect` (CS2-specific) and `onClick`
+> (standard HTML) are valid props. Always prefer `onSelect` — it integrates with
+> the game's input system (gamepad support, UI sounds). InfoLoom's actual source
+> uses `onClick` on flyout sub-buttons, which works but bypasses CS2 input handling.
 
 Key SCSS for the flyout panel:
 

--- a/site/mod-ui-buttons.html
+++ b/site/mod-ui-buttons.html
@@ -594,12 +594,21 @@ export const setMenuOpen = (open: boolean) =&gt; trigger(mod.id, "MenuOpen", ope
         &lt;header&gt;Info Loom&lt;/header&gt;
         {sections.map(name =&gt; (
             &lt;Button key={name} variant="flat"
-                onClick={() =&gt; toggleSection(name)}&gt;
+                onSelect={() =&gt; toggleSection(name)}&gt;
                 {name}
             &lt;/Button&gt;
         ))}
     &lt;/div&gt;
 )}</code></pre>
+
+<p>
+  <strong>Note on <code>onSelect</code> vs <code>onClick</code>:</strong> The <code>cs2/ui</code>
+  <code>Button</code> component extends <code>React.ButtonHTMLAttributes</code>, so both
+  <code>onSelect</code> (CS2-specific) and <code>onClick</code> (standard HTML) are valid props.
+  Always prefer <code>onSelect</code> -- it integrates with the game's input system (gamepad
+  support, UI sounds). InfoLoom's actual source uses <code>onClick</code> on flyout sub-buttons,
+  which works but bypasses CS2 input handling.
+</p>
 
 <p>Key SCSS for the flyout:</p>
 


### PR DESCRIPTION
## Summary
- Change InfoLoom flyout example to use `onSelect` consistently instead of mixing `onClick` and `onSelect`
- Add explanatory note clarifying that `cs2/ui` `Button` supports both props (via `React.ButtonHTMLAttributes` inheritance) but `onSelect` is recommended for CS2 input integration
- Updates both `research/topics/ModUIButtons/README.md` and `site/mod-ui-buttons.html`

## Test plan
- [ ] Verify all Button examples in ModUIButtons docs use `onSelect` consistently
- [ ] Confirm the note explains the onClick/onSelect distinction accurately

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)