### PR TITLE
fix: document ConsumptionData and PollutionParameterData.m_NoiseMultiplier

### DIFF
--- a/research/topics/ElectricityGrid/README.md
+++ b/research/topics/ElectricityGrid/README.md
@@ -289,8 +289,18 @@ Counts total production, consumption, and battery capacity for UI statistics.
 - `m_Direction`: FlowDirection (Forward, Backward, Both, None)
 - `m_Voltage`: Low (0) or High (1)
 
-### ConsumptionData (prefab)
-- `m_ElectricityConsumption`: Base electricity consumption for a building type
+### ConsumptionData (Game.Prefabs)
+
+Per-building-prefab component that defines base consumption for electricity and water. This is the starting point for `AdjustElectricityConsumptionSystem` and `AdjustWaterConsumptionSystem` calculations.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `m_ElectricityConsumption` | int | Base electricity consumption for this building type. Multiplied by temperature, fee, district, and occupancy modifiers in `AdjustElectricityConsumptionSystem`. |
+| `m_WaterConsumption` | int | Base water consumption for this building type. Used by `AdjustWaterConsumptionSystem` with similar multiplier chain. |
+
+Both fields represent the building's consumption at full occupancy under neutral conditions. The actual `WantedConsumption` written to `ElectricityConsumer.m_WantedConsumption` (or the water equivalent) is this base value multiplied by several factors. Community mods modify `ConsumptionData` on building prefabs at runtime to adjust per-building-type electricity and water demands. This is particularly useful for mods that want building consumption to reflect realistic values based on building size (see the Building Mesh Dimensions pattern in Zoning research).
+
+*Source: `Game.dll` -> `Game.Prefabs.ConsumptionData`*
 
 ## Harmony Patch Points
 

--- a/research/topics/Pollution/README.md
+++ b/research/topics/Pollution/README.md
@@ -134,6 +134,17 @@ Singleton component controlling global pollution parameters.
 | m_HomelessNoisePollution | int | Noise pollution per homeless citizen |
 | m_GroundPollutionLandValueDivisor | int | Divisor for ground pollution's land value impact |
 
+**Modding note on `m_NoiseMultiplier`**: The `m_NoiseMultiplier` field is the global scaling factor for ALL building noise pollution. `BuildingPollutionAddSystem` multiplies every building's `PollutionData.m_NoisePollution` by this value before applying distance-based spreading. Community mods that want quieter or louder cities can modify this singleton field at runtime:
+
+```csharp
+var paramQuery = GetEntityQuery(ComponentType.ReadWrite<PollutionParameterData>());
+var data = paramQuery.GetSingleton<PollutionParameterData>();
+data.m_NoiseMultiplier = 0.5f; // Halve all building noise
+paramQuery.SetSingleton(data);
+```
+
+Similarly, `m_GroundMultiplier` and `m_AirMultiplier` scale their respective pollution types globally. The net-specific multipliers (`m_NetAirMultiplier`, `m_NetNoiseMultiplier`) only affect road/traffic pollution via `NetPollutionSystem`.
+
 ### `PollutionModifierData` (Game.Prefabs)
 
 Upgrade component that modifies a building's pollution emission.

--- a/site/electricity-grid.html
+++ b/site/electricity-grid.html
@@ -419,6 +419,34 @@ public static class CustomProductionPatch
       </tr>
     </table>
 
+    <h3>ConsumptionData (Game.Prefabs)</h3>
+
+    <p>
+      Per-building-prefab component defining base consumption for electricity and water.
+      This is the starting point for <code>AdjustElectricityConsumptionSystem</code> and
+      <code>AdjustWaterConsumptionSystem</code> calculations.
+    </p>
+
+    <table>
+      <tr><th>Field</th><th>Type</th><th>Description</th></tr>
+      <tr>
+        <td><code>m_ElectricityConsumption</code></td>
+        <td><code>int</code></td>
+        <td>Base electricity consumption. Multiplied by temperature, fee, district, and occupancy modifiers.</td>
+      </tr>
+      <tr>
+        <td><code>m_WaterConsumption</code></td>
+        <td><code>int</code></td>
+        <td>Base water consumption. Used by <code>AdjustWaterConsumptionSystem</code> with similar multiplier chain.</td>
+      </tr>
+    </table>
+
+    <p>
+      Both fields represent consumption at full occupancy under neutral conditions. Community mods
+      modify <code>ConsumptionData</code> on building prefabs at runtime to adjust per-building-type
+      demands based on realistic values or building size.
+    </p>
+
     <h3>ElectricityParameterData (Singleton)</h3>
 
     <table>

--- a/site/pollution.html
+++ b/site/pollution.html
@@ -382,6 +382,21 @@ pollution2 = math.clamp(pollution2, 0, 32767);</code></pre>
     </tbody>
   </table>
 
+  <p>
+    <strong>Modding note on <code>m_NoiseMultiplier</code>:</strong> This is the global scaling factor
+    for ALL building noise pollution. <code>BuildingPollutionAddSystem</code> multiplies every building's
+    <code>PollutionData.m_NoisePollution</code> by this value before applying distance-based spreading.
+    Similarly, <code>m_GroundMultiplier</code> and <code>m_AirMultiplier</code> scale their respective
+    types globally. The net-specific multipliers (<code>m_NetAirMultiplier</code>,
+    <code>m_NetNoiseMultiplier</code>) only affect road/traffic pollution.
+  </p>
+
+  <pre><code class="language-csharp">// Halve all building noise pollution globally
+var paramQuery = GetEntityQuery(ComponentType.ReadWrite&lt;PollutionParameterData&gt;());
+var data = paramQuery.GetSingleton&lt;PollutionParameterData&gt;();
+data.m_NoiseMultiplier = 0.5f;
+paramQuery.SetSingleton(data);</code></pre>
+
   <h3>PollutionModifierData (Game.Prefabs)</h3>
 
   <p>Upgrade component that modifies a building's pollution. Multiple upgrades combine additively,


### PR DESCRIPTION
## Summary
- Expand ConsumptionData docs in ElectricityGrid with both electricity and water fields
- Add modding note for PollutionParameterData.m_NoiseMultiplier with runtime modification example

## Test plan
- [ ] Verify new sections in both README.md and HTML files
- [ ] Check HTML escaping

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)