### PR TITLE
fix: update target framework to net472

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ ModName/
 ├── CHANGELOG.md
 ├── src/
 │   └── ModName/
-│       ├── ModName.csproj   # .NET Standard 2.1
+│       ├── ModName.csproj   # .NET Framework (see Target Framework below)
 │       ├── Mod.cs           # Entry point (implements IMod)
 │       ├── Settings/        # Mod settings classes
 │       ├── Systems/         # ECS game systems (one per file)
@@ -54,7 +54,7 @@ ModName/
 ## CS2-Specific Patterns
 
 - Entry point: class implementing `IMod` with `OnLoad`/`OnDispose`
-- Target: **.NET Standard 2.1** (game uses Unity 2022.3.7f1 Mono runtime)
+- Target: **net472** (community standard -- Unity 2022.3.7f1 Mono runtime is .NET Framework-compatible). `netstandard2.1` also works since .NET Framework 4.7.2 implements .NET Standard 2.0, but most community mods (RealisticWorkplacesAndHouseholds, TransportPolicyAdjuster, RealisticParking, etc.) target `net472` because it provides access to the full .NET Framework API surface that Unity's Mono runtime supports, including types like `System.Drawing` and `System.Net.Http` not available in .NET Standard 2.1.
 - Reference game assemblies from `Cities2_Data/Managed/` with Copy Local = No
 - Use ECS systems (`GameSystemBase`) for simulation logic
 - Use Harmony (`HarmonyLib`) for patching existing game methods

--- a/docs/project-setup.md
+++ b/docs/project-setup.md
@@ -17,7 +17,7 @@
 
 Key settings in your `.csproj`:
 
-- **TargetFramework**: `netstandard2.1`
+- **TargetFramework**: `net472` (community standard). Unity 2022.3.7f1's Mono runtime is .NET Framework-compatible, and most community mods (RealisticWorkplacesAndHouseholds, TransportPolicyAdjuster, RealisticParking, etc.) target `net472`. This gives access to the full .NET Framework API surface that Unity's Mono runtime supports, including types like `System.Drawing` and `System.Net.Http`. The alternative `netstandard2.1` also compiles and loads correctly, but provides a smaller API surface. Use `net472` unless you have a specific reason to target .NET Standard.
 - **Game references**: Point to `Cities2_Data/Managed/`, set `Private="false"` (don't copy game DLLs)
 - **Post-build**: Copy output DLL to the game's Mods folder
 


### PR DESCRIPTION
## Summary
- Update CLAUDE.md and docs/project-setup.md to document `net472` as the community standard target framework instead of `netstandard2.1`
- Add explanation of both options and when to use each
- Community mods (RealisticWorkplacesAndHouseholds, TransportPolicyAdjuster, RealisticParking) all use `net472`

Closes #129
Closes #156
Closes #160

## Test plan
- [ ] Verify CLAUDE.md reflects net472 as the target
- [ ] Verify docs/project-setup.md csproj section documents net472 with explanation

🤖 Generated with [Claude Code](https://claude.com/claude-code)