### PR TITLE
fix: document PublicOnly flag and CustomPriority intersection modding

### DIFF
--- a/research/topics/TrafficFlowLaneControl/README.md
+++ b/research/topics/TrafficFlowLaneControl/README.md
@@ -118,6 +118,7 @@ Per-lane network property flags. These define the traffic rules for each lane.
 | ForbidPassing | 0x2000000 | Passing is forbidden on this lane |
 | RightOfWay | 0x4000000 | Lane has right of way |
 | TrafficLights | 0x8000000 | Lane is controlled by traffic lights |
+| PublicOnly | 0x20000000 | Lane is restricted to public transport vehicles only (bus-only lanes). Vehicles without `CarFlags.UsePublicTransportLanes` are excluded. |
 | Forbidden | 0x40000000 | Lane is forbidden for general traffic |
 | AllowEnter | 0x80000000 | Lane allows entering from adjacent |
 
@@ -214,6 +215,18 @@ Per-lane signal state. Attached to each lane at a signalized intersection.
 | m_Flags | LaneSignalFlags | CanExtend, Physical |
 
 *Source: `Game.dll` -> `Game.Net.LaneSignal`*
+
+#### CustomPriority for Intersection Priority Modding
+
+The `m_Priority` field on `LaneSignal` is the key to modding intersection priority behavior. When the `TrafficLightInitializationSystem` groups lanes into signal groups, it sets `m_Default` to the base priority. Mods can write a different value to `m_Priority` to create a **CustomPriority** override -- the traffic light state machine in `TrafficLightSystem` uses `m_Priority` (not `m_Default`) when evaluating which signal group to green next.
+
+To implement custom intersection priorities:
+1. Query intersection nodes with `TrafficLights` + `SubLane` buffer
+2. For each sub-lane with `LaneSignal`, set `m_Priority` to the desired value
+3. Higher `m_Priority` values give that lane's signal group preference in `GetNextSignalGroup`
+4. The system respects the priority on each tick, so mods can dynamically adjust priority based on time of day, traffic conditions, or emergency vehicle approach
+
+This is the recommended approach for intersection priority mods rather than patching `TrafficLightSystem` directly.
 
 ### `LaneSignalType` (Game.Net)
 

--- a/site/traffic-flow.html
+++ b/site/traffic-flow.html
@@ -138,9 +138,17 @@
     (EndOfPath, IsBlocked, TurnLeft, Queue, Roundabout, etc.). These describe what the
     vehicle is currently doing.</li>
     <li><strong><code>Game.Net.CarLaneFlags</code></strong> -- per-lane network property flags
-    (Highway, Yield, Stop, TrafficLights, Roundabout, ForbidPassing, etc.). These define
+    (Highway, Yield, Stop, TrafficLights, Roundabout, ForbidPassing, PublicOnly, etc.). These define
     the traffic rules for each lane.</li>
   </ul>
+
+  <p>
+    <strong>PublicOnly flag (0x20000000):</strong> The <code>CarLaneFlags.PublicOnly</code> flag marks
+    a lane as restricted to public transport vehicles only (bus-only lanes). Vehicles must have
+    <code>CarFlags.UsePublicTransportLanes</code> set to use these lanes. The lane selection cost
+    calculator in <code>CarLaneSelectIterator</code> treats PublicOnly lanes as forbidden for
+    vehicles without the appropriate flag, applying the forbidden lane cost penalty (0.9 or 4.9).
+  </p>
 
   <h3>Lane Selection: Cost-Based Optimization</h3>
 
@@ -376,6 +384,27 @@
       <tr><td>m_Flags</td><td>LaneSignalFlags</td><td>CanExtend, Physical</td></tr>
     </tbody>
   </table>
+
+  <h4>CustomPriority for Intersection Priority Modding</h4>
+  <p>
+    The <code>m_Priority</code> field on <code>LaneSignal</code> is the key to modding intersection
+    priority behavior. <code>TrafficLightInitializationSystem</code> sets <code>m_Default</code> to the
+    base priority when signal groups are created. Mods can write a different value to
+    <code>m_Priority</code> to create a <strong>CustomPriority</strong> override -- the traffic light
+    state machine uses <code>m_Priority</code> (not <code>m_Default</code>) when evaluating which
+    signal group to green next via <code>GetNextSignalGroup</code>.
+  </p>
+  <p>To implement custom intersection priorities:</p>
+  <ol>
+    <li>Query intersection nodes with <code>TrafficLights</code> + <code>SubLane</code> buffer</li>
+    <li>For each sub-lane with <code>LaneSignal</code>, set <code>m_Priority</code> to the desired value</li>
+    <li>Higher <code>m_Priority</code> values give that lane's signal group preference</li>
+    <li>The system checks priority each tick, so mods can dynamically adjust based on time of day, traffic conditions, or emergency vehicle approach</li>
+  </ol>
+  <p>
+    This is the recommended approach for intersection priority mods rather than patching
+    <code>TrafficLightSystem</code> directly.
+  </p>
 
   <h3>Bottleneck (Game.Net)</h3>
 


### PR DESCRIPTION
## Summary
- Document `CarLaneFlags.PublicOnly` (Game.Net, 0x20000000) for bus-only lanes, explaining how it restricts lanes to vehicles with `CarFlags.UsePublicTransportLanes`
- Document `CustomPriority` as the recommended approach for intersection priority modding via `LaneSignal.m_Priority` field, with step-by-step implementation guide

## Test plan
- [ ] Verify README.md CarLaneFlags table includes PublicOnly with value and description
- [ ] Verify README.md has CustomPriority section after LaneSignal component
- [ ] Verify traffic-flow.html has PublicOnly note and CustomPriority section with implementation steps
- [ ] Confirm HTML properly escapes < > as &lt; &gt;

Closes #216
Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)