### PR TITLE
fix: explain ObjectToolSystem Line and Curve placement modes

### DIFF
--- a/research/topics/ObjectToolSystem/README.md
+++ b/research/topics/ObjectToolSystem/README.md
@@ -119,9 +119,13 @@ Upgrade = 1  // Upgrade an existing object
 Move = 2     // Move an existing object
 Brush = 3    // Paint objects with brush
 Stamp = 4    // Stamp a group of objects
-Line = 5     // Place objects along a line
-Curve = 6    // Place objects along a curve
+Line = 5     // Place objects along a straight line between two control points
+Curve = 6    // Place objects along a curved path defined by three control points
 ```
+
+**Line mode (5)**: The user places two control points defining the start and end of a straight line. The tool uses `NetCourse` entities (the same system used by `NetToolSystem` for roads) to define the path. `CreateDefinitionsJob` then distributes objects evenly along the line based on the object's size from `ObjectGeometryData`. The spacing between objects equals the object's size along the placement axis, ensuring objects are placed edge-to-edge without overlap. The tool registers the "Place Net Edge" and "Undo Net Control Point" input actions to support this mode.
+
+**Curve mode (6)**: The user places three control points defining a Bezier curve -- start, midpoint, and end. Like Line mode, this uses `NetCourse` entities to represent the curved path. `CreateDefinitionsJob` distributes objects evenly along the curve's arc length, again spacing them based on `ObjectGeometryData` size. Objects are rotated to follow the curve tangent at each placement point. Both Line and Curve modes require the `Brushable` flag on the prefab's `ObjectGeometryData` to be available.
 
 ### `CreationFlags`
 

--- a/site/object-tool-system.html
+++ b/site/object-tool-system.html
@@ -162,8 +162,8 @@
       <tr><td>Move</td><td>2</td><td>Relocate an existing object to a new position</td></tr>
       <tr><td>Brush</td><td>3</td><td>Paint objects across an area using a brush (trees, props)</td></tr>
       <tr><td>Stamp</td><td>4</td><td>Place a predefined group/pattern of objects at once</td></tr>
-      <tr><td>Line</td><td>5</td><td>Place objects evenly along a straight line</td></tr>
-      <tr><td>Curve</td><td>6</td><td>Place objects evenly along a curved path</td></tr>
+      <tr><td>Line</td><td>5</td><td>Place objects evenly along a straight line between two control points</td></tr>
+      <tr><td>Curve</td><td>6</td><td>Place objects evenly along a curved path defined by three control points</td></tr>
     </tbody>
   </table>
 
@@ -176,6 +176,24 @@
     <li><strong>Stampable</strong> objects enable Stamp mode</li>
     <li>Trees also enable the <strong>age mask</strong> selector (Sapling, Young, Mature, Elderly)</li>
   </ul>
+
+  <h3>Line and Curve Mode Details</h3>
+
+  <p>
+    <strong>Line mode (5)</strong> lets the user place two control points defining a straight line.
+    The tool reuses <code>NetCourse</code> entities (the same system used by <code>NetToolSystem</code>
+    for roads) to define the path. <code>CreateDefinitionsJob</code> distributes objects evenly along
+    the line based on the object's size from <code>ObjectGeometryData</code>. Spacing equals the
+    object's size along the placement axis, ensuring edge-to-edge placement without overlap.
+  </p>
+
+  <p>
+    <strong>Curve mode (6)</strong> works similarly but with three control points defining a Bezier
+    curve (start, midpoint, end). Objects are distributed evenly along the curve's arc length and
+    rotated to follow the curve tangent at each placement point. Both modes register the
+    "Place Net Edge" and "Undo Net Control Point" input actions and require the <code>Brushable</code>
+    flag on the prefab's <code>ObjectGeometryData</code>.
+  </p>
 
   <!-- ============================================================ -->
   <h2>Key Components</h2>


### PR DESCRIPTION
## Summary
- Explain what Line (mode 5) and Curve (mode 6) modes do in ObjectToolSystem
- Line mode uses two control points for straight-line object distribution
- Curve mode uses three control points for Bezier curve object distribution
- Both reuse NetCourse entities and space objects based on ObjectGeometryData size

Closes #225

## Test plan
- [ ] Verify README.md mode descriptions are clear and accurate
- [ ] Verify HTML page new section renders properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)