### PR TITLE
fix: include route modifiers in DistrictsPolicies scope

### DIFF
--- a/research/topics/DistrictsPolicies/README.md
+++ b/research/topics/DistrictsPolicies/README.md
@@ -10,7 +10,7 @@
 
 **Why**: Mods need to create custom policies, apply modifiers to districts, read which district an entity belongs to, and react to policy changes.
 
-**Boundaries**: Building-level modifiers and city-wide modifiers are referenced but not deeply documented here. Route modifiers (transit lines) are out of scope.
+**Boundaries**: This research covers all four policy scopes handled by `ModifiedSystem`: District, Building, Route (transit lines), and City. Building-level and city-wide modifiers share the same architecture but their specific modifier types are not exhaustively listed here.
 
 ## Relevant Assemblies & Namespaces
 
@@ -239,6 +239,19 @@
   - `ModifyPolicyJob.Execute()` -- Processes Modify events: adds/removes/updates Policy entries in the target entity's Policy buffer, then calls RefreshEffects
   - `RefreshEffects()` -- Delegates to the appropriate refresh system (district, building, route, or city) to recalculate modifiers
   - `GetPolicyRange()` -- Determines scope: District, Building, Route, or City
+
+### Policy Scope: All Four Targets
+
+`ModifiedSystem.GetPolicyRange()` determines which scope a policy targets. The same `Policy` buffer and `Modify` event pattern is used for all four:
+
+| Scope | Target Entity | Modifier Buffer | Example Policies |
+|-------|---------------|-----------------|------------------|
+| District | Area entity with `District` component | `DistrictModifier` | Speed limits, parking fees, traffic bans |
+| Building | Building entity with service upgrades | `BuildingModifier` | Service building efficiency adjustments |
+| Route | Transit route entity (bus/tram/train line) | `RouteModifier` | Ticket price, vehicle frequency adjustments |
+| City | City-wide singleton entity | `CityModifier` | City-wide tax rates, global service adjustments |
+
+Route modifiers work identically to district modifiers: `ModifiedSystem` processes the `Modify` event, updates the `Policy` buffer on the route entity, and calls `RefreshEffects()` which delegates to the route-specific refresh logic to rebuild the `RouteModifier` buffer.
 
 ### `LanePoliciesSystem` (Game.Pathfind)
 

--- a/site/districts-policies.html
+++ b/site/districts-policies.html
@@ -111,8 +111,10 @@
       <code>BorderDistrict</code>.
     </p>
     <p>
-      <strong>Out of scope:</strong> Building-level modifiers, route (transit line) modifiers, and
-      city-wide modifiers share a similar architecture but are not deeply covered here.
+      <strong>Note:</strong> <code>ModifiedSystem</code> handles all four policy scopes: District,
+      Building, Route (transit lines), and City. They share the same architecture (Policy buffer +
+      Modify events). Building-level and city-wide modifier types are referenced but not
+      exhaustively listed here.
     </p>
   </div>
 
@@ -352,6 +354,28 @@
       <tr><td>4</td><td>ForbidBicycles</td><td>Bans bicycles</td></tr>
     </tbody>
   </table>
+
+  <h3>All Four Policy Scopes</h3>
+
+  <p><code>ModifiedSystem.GetPolicyRange()</code> determines which scope a policy targets. The same
+  <code>Policy</code> buffer and <code>Modify</code> event pattern is used for all four:</p>
+
+  <table>
+    <thead>
+      <tr><th>Scope</th><th>Target Entity</th><th>Modifier Buffer</th><th>Example Policies</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>District</td><td>Area entity with <code>District</code></td><td><code>DistrictModifier</code></td><td>Speed limits, parking fees, traffic bans</td></tr>
+      <tr><td>Building</td><td>Building entity with service upgrades</td><td><code>BuildingModifier</code></td><td>Service building efficiency adjustments</td></tr>
+      <tr><td>Route</td><td>Transit route entity (bus/tram/train line)</td><td><code>RouteModifier</code></td><td>Ticket price, vehicle frequency adjustments</td></tr>
+      <tr><td>City</td><td>City-wide singleton entity</td><td><code>CityModifier</code></td><td>City-wide tax rates, global service adjustments</td></tr>
+    </tbody>
+  </table>
+
+  <p>Route modifiers work identically to district modifiers: <code>ModifiedSystem</code> processes
+  the <code>Modify</code> event, updates the <code>Policy</code> buffer on the route entity, and
+  calls <code>RefreshEffects()</code> which delegates to the route-specific refresh logic to rebuild
+  the <code>RouteModifier</code> buffer.</p>
 
   <!-- ============================================================ -->
   <h2>Data Flow</h2>


### PR DESCRIPTION
## Summary
- Fix the scope boundary to include route modifiers -- `ModifiedSystem` handles all 4 scopes (District, Building, Route, City)
- Add a table documenting all four policy scopes with target entities, modifier buffers, and example policies
- Route modifiers use the same architecture as district modifiers

Closes #150

## Test plan
- [ ] Verify README.md scope section no longer excludes route modifiers
- [ ] Verify HTML page shows the four-scope table correctly
- [ ] Confirm route modifier explanation is clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)